### PR TITLE
Sketchy fix for draw_framebuffer

### DIFF
--- a/main/esp32_ssd1306.c
+++ b/main/esp32_ssd1306.c
@@ -299,7 +299,9 @@ void ssd1306_write_string(char *str)
     int chars_to_fit = (SSD1306_WIDTH - ssd1306_dev.x) / SSD1306_CHAR_WIDTH;
     int i = 0;
 
+
     while (*str && i++ < chars_to_fit) {
+              
         ssd1306_write_char(*str);
         str++;
     }
@@ -312,13 +314,22 @@ void ssd1306_draw_framebuffer(char **buf, int cursor_x)
     if (cursor_x >= SSD1306_WIDTH_CHARS) {
         offset += cursor_x - SSD1306_WIDTH_CHARS;
     }
-
-    for (unsigned char i = 0; i < SSD1306_HEIGHT_CHARS; i++) {
+    
+    if (buf == NULL )
+    {
+        ESP_LOGI(__func__, "Buf = null pointer");
+    }
+    else
+    {
+        for (unsigned char i = 0; i < SSD1306_HEIGHT_CHARS; i++) {
         ssd1306_set_draw_cursor(SSD1306_X_OFFSET,
                                 SSD1306_Y_OFFSET +
-                                i * SSD1306_CHAR_HEIGHT);
-        ssd1306_write_string(buf[i] + offset);
+                                i * SSD1306_CHAR_HEIGHT);           
+        ssd1306_write_string(buf[i] + offset); 
     }
+    }
+    
+
 }
 
 void ssd1306_draw_cursor(unsigned char state, int x, int y)


### PR DESCRIPTION
Included a check for null pointer in order to prevent deref. of null pointer in line 320